### PR TITLE
Prevent forced setting of bg and termguicolors

### DIFF
--- a/lua/lunar/init.lua
+++ b/lua/lunar/init.lua
@@ -4,12 +4,10 @@ local theme = require('lunar.theme')
 M.setup = function()
   vim.cmd('hi clear')
 
-  vim.o.background = 'dark'
   if vim.fn.exists('syntax_on') then
     vim.cmd('syntax reset')
   end
 
-  vim.o.termguicolors = true
   vim.g.colors_name = 'lunar'
 
   theme.set_highlights()


### PR DESCRIPTION
Prevent the setting of ` vim.o.background` and `vim.o.termguicolors` which should be left up to the user.

Closes #1